### PR TITLE
Added bogus to unittests

### DIFF
--- a/test/Chirp.Infrastructure.Tests/AuthorRepositoryTests.cs
+++ b/test/Chirp.Infrastructure.Tests/AuthorRepositoryTests.cs
@@ -120,7 +120,7 @@ public class AuthorRepositoryTests
     public void CanCreateAuthorWithLongName()
     {
         // Arrange
-        AuthorDTO authorDTO = new AuthorDTO("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "hejsameddejsa@gmail.com");
+        AuthorDTO authorDTO = new AuthorDTO("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "Cohen.Spears@gmail.com");
 
         // Act and Assert
         try

--- a/test/Chirp.Infrastructure.Tests/AuthorRepositoryTests.cs
+++ b/test/Chirp.Infrastructure.Tests/AuthorRepositoryTests.cs
@@ -16,11 +16,11 @@ public class AuthorRepositoryTests
 
     private static void SeedDatabase(ChirpContext context)
     {
-        Author a1 = new Author() { Name = "hejsameddejsa", Email = "hejsameddejsa@gmail.com", Cheeps = new List<Cheep>() };
-        Author a2 = new Author() { Name = "f1skef1let", Email = "f1skef1let@coldmail.com", Cheeps = new List<Cheep>() };
-        Author a3 = new Author() { Name = "IsbjørnOgSkruetrækker", Email = "isbjørnogskruetrækker@hotmail.com", Cheeps = new List<Cheep>() };
-        Author a4 = new Author() { Name = "GetCheepsFromAuthor", Email = "anotheremail@email.dk", Cheeps = new List<Cheep>() };
-        Author a5 = new Author() { Name = "ThisAuthorHasNoCheeps", Email = "DAMthisisamail@email.dk", Cheeps = new List<Cheep>() };
+        Author a1 = DataGenerator.GenerateAuthor(1);
+        Author a2 = DataGenerator.GenerateAuthor(2);
+        Author a3 = DataGenerator.GenerateAuthor(3);
+        Author a4 = DataGenerator.GenerateAuthor(4);
+        Author a5 = DataGenerator.GenerateAuthor(5);
 
         List<Author> authors = new List<Author>() { a1, a2, a3, a4, a5 };
 
@@ -36,80 +36,83 @@ public class AuthorRepositoryTests
     }
 
     [Theory]
-    [InlineData("Simon", "simr@itu.dk")]
-    [InlineData("Annabell", "apno@itu.dk")]
-    [InlineData("Johnnie Calixto", "Jacqualine.Gilcoine@gmail.com")]
-    public async void CanCreateAuthorCanGetAuthorFromName(string name, string email)
+    [InlineData(10)]
+    [InlineData(15)]
+    [InlineData(20)]
+    public async void CanCreateAuthorCanGetAuthorFromName(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = new AuthorDTO(name, email);
+        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
 
         // Act
         _repository.CreateAuthor(authorDTO);
-        AuthorDTO author = await _repository.GetAuthorFromNameAsync(name);
+        AuthorDTO author = await _repository.GetAuthorFromNameAsync(authorDTO.Name);
 
         // Assert
-        Assert.Equal(name, author.Name);
-        Assert.Equal(email, author.Email);
+        Assert.Equal(authorDTO.Name, author.Name);
+        Assert.Equal(authorDTO.Email, author.Email);
         Assert.Equal(authorDTO, author);
     }
 
     [Theory]
-    [InlineData("Simon", "simr@itu.dk")]
-    [InlineData("Annabell", "apno@itu.dk")]
-    [InlineData("Johnnie Calixto", "Jacqualine.Gilcoine@gmail.com")]
-    public async void CanCreateAuthorCanGetAuthorFromEmail(string name, string email)
+    [InlineData(10)]
+    [InlineData(15)]
+    [InlineData(20)]
+    public async void CanCreateAuthorCanGetAuthorFromEmail(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = new AuthorDTO(name, email);
+        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
 
         // Act
         _repository.CreateAuthor(authorDTO);
-        AuthorDTO author = await _repository.GetAuthorFromEmailAsync(email);
+        AuthorDTO author = await _repository.GetAuthorFromEmailAsync(authorDTO.Email);
 
         // Assert
-        Assert.Equal(name, author.Name);
-        Assert.Equal(email, author.Email);
+        Assert.Equal(authorDTO.Name, author.Name);
+        Assert.Equal(authorDTO.Email, author.Email);
         Assert.Equal(authorDTO, author);
     }
 
-    [Theory]  
-    [InlineData("hejsameddejsa", "simr@itu.dk")]
-    [InlineData("f1skef1let", "apno@itu.dk")]
-    [InlineData("IsbjørnOgSkruetrækker", "Jacqualine.Gilcoine@gmail.com")]  
-    public void CanCreateAuthorWhereNameExists(string name, string email)    
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void CanCreateAuthorWhereNameExists(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = new AuthorDTO(name, email);
+        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
 
         // Act and Assert
         try
         {
             _repository.CreateAuthor(authorDTO);
+            Assert.Fail();
         }
         catch (ArgumentException e)
         {
-            Assert.Equal($"An author already exists with name: '{name}'", e.Message);
+            Assert.Equal($"An author already exists with name: '{authorDTO.Name}'", e.Message);
         }
     }
 
     [Theory]
-    [InlineData("Simon", "hejsameddejsa@gmail.com")]
-    [InlineData("Annabell", "f1skef1let@coldmail.com")]
-    [InlineData("Johnnie Calixto", "isbjørnogskruetrækker@hotmail.com")]
-    public void CanCreateAuthorWhereEmailExists(string name, string email)
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void CanCreateAuthorWhereEmailExists(int seed)
     {
         //Arrange
-        AuthorDTO authorDTO = new AuthorDTO(name, email);
+        AuthorDTO tempAuthorDTO = DataGenerator.GenerateAuthorDTO(seed);
+        AuthorDTO authorDTO = new AuthorDTO("Cohen Spears", tempAuthorDTO.Email);
 
         //Act and Assert
         try
         {
             _repository.CreateAuthor(authorDTO);
+            Assert.Fail();
         }
         catch (ArgumentException e)
         {
-            Assert.Equal($"An author already exists with email: '{email}'", e.Message);
+            Assert.Equal($"An author already exists with email: '{authorDTO.Email}'", e.Message);
         }
     }
 
@@ -119,9 +122,11 @@ public class AuthorRepositoryTests
         // Arrange
         AuthorDTO authorDTO = new AuthorDTO("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "hejsameddejsa@gmail.com");
 
+        // Act and Assert
         try
         {
             _repository.CreateAuthor(authorDTO);
+            Assert.Fail();
         }
         catch (ArgumentException e)
         {
@@ -130,64 +135,80 @@ public class AuthorRepositoryTests
     }
 
     [Theory]
-    [InlineData("hejsameddejsa", "hejsameddejsa@gmail.com")]
-    [InlineData("f1skef1let", "f1skef1let@coldmail.com")]
-    [InlineData("IsbjørnOgSkruetrækker", "isbjørnogskruetrækker@hotmail.com")]
-    public async void CanGetAuthorFromName(string name, string email)
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public async void CanGetAuthorFromName(int seed)
     {
+        // Arrange
+        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+
         // Act
-        AuthorDTO author = await _repository.GetAuthorFromNameAsync(name);
+        AuthorDTO author = await _repository.GetAuthorFromNameAsync(authorDTO.Name);
 
         // Assert
-        Assert.Equal(name, author.Name);
-        Assert.Equal(email, author.Email);
+        Assert.Equal(author.Name, author.Name);
+        Assert.Equal(author.Email, author.Email);
+        Assert.Equal(authorDTO, author);
     }
 
     [Theory]
-    [InlineData("rødspætte")]
-    [InlineData("skrubbe")]
-    [InlineData("søtunge")]
-    public async void CanGetAuthorFromNameWhichDoesNotExists(string name)
+    [InlineData(10)]
+    [InlineData(15)]
+    [InlineData(20)]
+    public async void CanGetAuthorFromNameWhichDoesNotExists(int seed)
     {
+        // Arrange
+        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+
         // Act and Assert
         try
         {
-            Assert.Null(await _repository.GetAuthorFromNameAsync(name));
+            Assert.Null(await _repository.GetAuthorFromNameAsync(authorDTO.Name));
+            Assert.Fail();
         }
         catch (ArgumentException e)
         {
-            Assert.Equal($"No author with name: '{name}'", e.Message);
+            Assert.Equal($"No author with name: '{authorDTO.Name}'", e.Message);
         }
     }
 
     [Theory]
-    [InlineData("hejsameddejsa", "hejsameddejsa@gmail.com")]
-    [InlineData("f1skef1let", "f1skef1let@coldmail.com")]
-    [InlineData("IsbjørnOgSkruetrækker", "isbjørnogskruetrækker@hotmail.com")]
-    public async void CanGetAuthorFromEmail(string name, string email)
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public async void CanGetAuthorFromEmail(int seed)
     {
+        // Arrange
+        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+
         // Act
-        AuthorDTO author = await _repository.GetAuthorFromEmailAsync(email);
+        AuthorDTO author = await _repository.GetAuthorFromEmailAsync(authorDTO.Email);
 
         // Assert
-        Assert.Equal(name, author.Name);
-        Assert.Equal(email, author.Email);
+        Assert.Equal(authorDTO.Name, author.Name);
+        Assert.Equal(authorDTO.Email, author.Email);
+        Assert.Equal(authorDTO, author);
     }
 
     [Theory]
-    [InlineData("rødspætte@hotmail.com")]
-    [InlineData("skrubbe@email.dk")]
-    [InlineData("søtunge@gmail.com")]
-    public async void CanGetAuthorFromEmailWhichDoesNotExists(string email)
+    [InlineData(10)]
+    [InlineData(15)]
+    [InlineData(20)]
+    public async void CanGetAuthorFromEmailWhichDoesNotExists(int seed)
     {
+        // Arrange
+        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+
         // Act and Assert
         try
         {
-            Assert.Null(await _repository.GetAuthorFromEmailAsync(email));
+            Assert.Null(await _repository.GetAuthorFromEmailAsync(authorDTO.Email));
+            Assert.Fail();
         }
         catch (ArgumentException e)
         {
-            Assert.Equal($"No author with email: '{email}'", e.Message);
+            Assert.Equal($"No author with email: '{authorDTO.Email}'", e.Message);
         }
     }
 }

--- a/test/Chirp.Infrastructure.Tests/AuthorRepositoryTests.cs
+++ b/test/Chirp.Infrastructure.Tests/AuthorRepositoryTests.cs
@@ -16,11 +16,13 @@ public class AuthorRepositoryTests
 
     private static void SeedDatabase(ChirpContext context)
     {
-        Author a1 = DataGenerator.GenerateAuthor(1);
-        Author a2 = DataGenerator.GenerateAuthor(2);
-        Author a3 = DataGenerator.GenerateAuthor(3);
-        Author a4 = DataGenerator.GenerateAuthor(4);
-        Author a5 = DataGenerator.GenerateAuthor(5);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        Author a1 = dataGenerator.GenerateAuthor(1);
+        Author a2 = dataGenerator.GenerateAuthor(2);
+        Author a3 = dataGenerator.GenerateAuthor(3);
+        Author a4 = dataGenerator.GenerateAuthor(4);
+        Author a5 = dataGenerator.GenerateAuthor(5);
 
         List<Author> authors = new List<Author>() { a1, a2, a3, a4, a5 };
 
@@ -42,7 +44,9 @@ public class AuthorRepositoryTests
     public async void CanCreateAuthorCanGetAuthorFromName(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(seed);
 
         // Act
         _repository.CreateAuthor(authorDTO);
@@ -61,7 +65,9 @@ public class AuthorRepositoryTests
     public async void CanCreateAuthorCanGetAuthorFromEmail(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(seed);
 
         // Act
         _repository.CreateAuthor(authorDTO);
@@ -80,7 +86,9 @@ public class AuthorRepositoryTests
     public void CanCreateAuthorWhereNameExists(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(seed);
 
         // Act and Assert
         try
@@ -101,7 +109,9 @@ public class AuthorRepositoryTests
     public void CanCreateAuthorWhereEmailExists(int seed)
     {
         //Arrange
-        AuthorDTO tempAuthorDTO = DataGenerator.GenerateAuthorDTO(seed);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO tempAuthorDTO = dataGenerator.GenerateAuthorDTO(seed);
         AuthorDTO authorDTO = new AuthorDTO("Cohen Spears", tempAuthorDTO.Email);
 
         //Act and Assert
@@ -141,7 +151,9 @@ public class AuthorRepositoryTests
     public async void CanGetAuthorFromName(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(seed);
 
         // Act
         AuthorDTO author = await _repository.GetAuthorFromNameAsync(authorDTO.Name);
@@ -159,7 +171,9 @@ public class AuthorRepositoryTests
     public async void CanGetAuthorFromNameWhichDoesNotExists(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(seed);
 
         // Act and Assert
         try
@@ -180,7 +194,9 @@ public class AuthorRepositoryTests
     public async void CanGetAuthorFromEmail(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(seed);
 
         // Act
         AuthorDTO author = await _repository.GetAuthorFromEmailAsync(authorDTO.Email);
@@ -198,7 +214,9 @@ public class AuthorRepositoryTests
     public async void CanGetAuthorFromEmailWhichDoesNotExists(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(seed);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(seed);
 
         // Act and Assert
         try

--- a/test/Chirp.Infrastructure.Tests/CheepRepositoryTests.cs
+++ b/test/Chirp.Infrastructure.Tests/CheepRepositoryTests.cs
@@ -16,19 +16,21 @@ public class CheepRepositoryTests
 
     private static void SeedDatabase(ChirpContext context)
     {
-        Author a1 = DataGenerator.GenerateAuthor(1);
-        Author a2 = DataGenerator.GenerateAuthor(2);
-        Author a3 = DataGenerator.GenerateAuthor(3);
-        Author a4 = DataGenerator.GenerateAuthor(4);
-        Author a5 = DataGenerator.GenerateAuthor(5);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        Author a1 = dataGenerator.GenerateAuthor(1);
+        Author a2 = dataGenerator.GenerateAuthor(2);
+        Author a3 = dataGenerator.GenerateAuthor(3);
+        Author a4 = dataGenerator.GenerateAuthor(4);
+        Author a5 = dataGenerator.GenerateAuthor(5);
 
         List<Author> authors = new List<Author>() { a1, a2, a3, a4, a5 };
 
-        Cheep c1 = DataGenerator.GenerateCheep(1, a5);
-        Cheep c2 = DataGenerator.GenerateCheep(2, a5);
-        Cheep c3 = DataGenerator.GenerateCheep(3, a5);
-        Cheep c4 = DataGenerator.GenerateCheep(4, a5);
-        Cheep c5 = DataGenerator.GenerateCheep(5, a5);
+        Cheep c1 = dataGenerator.GenerateCheep(1, a5);
+        Cheep c2 = dataGenerator.GenerateCheep(2, a5);
+        Cheep c3 = dataGenerator.GenerateCheep(3, a5);
+        Cheep c4 = dataGenerator.GenerateCheep(4, a5);
+        Cheep c5 = dataGenerator.GenerateCheep(5, a5);
 
         List<Cheep> cheeps = new List<Cheep>() { c1, c2, c3, c4, c5 };
         a5.Cheeps = new List<Cheep>() { c1, c2, c3, c4, c5 };
@@ -52,8 +54,10 @@ public class CheepRepositoryTests
     public async void CanCreateCheep(int seed)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(1);
-        CheepDTO cheepDTO = DataGenerator.GenerateCheepDTO(seed, authorDTO);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(1);
+        CheepDTO cheepDTO = dataGenerator.GenerateCheepDTO(seed, authorDTO);
 
         // Act
         _repository.CreateCheep(cheepDTO);
@@ -72,8 +76,10 @@ public class CheepRepositoryTests
     public void CanCreateCheepWhereAuthorDoesNotExists()
     {
         //Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(6);
-        CheepDTO cheepDTO = DataGenerator.GenerateCheepDTO(6, authorDTO);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(6);
+        CheepDTO cheepDTO = dataGenerator.GenerateCheepDTO(6, authorDTO);
 
         //Act and Assert
         try
@@ -109,8 +115,10 @@ public class CheepRepositoryTests
     public async void CanGetCheeps()
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(5);
-        CheepDTO cheepDTO = DataGenerator.GenerateCheepDTO(5, authorDTO);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(5);
+        CheepDTO cheepDTO = dataGenerator.GenerateCheepDTO(5, authorDTO);
 
         // Act
         IEnumerable<CheepDTO> cheeps = await _repository.GetCheepsAsync(1, 1);
@@ -176,8 +184,10 @@ public class CheepRepositoryTests
     public async void CanGetCheepsFromAuthor()
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(5);
-        CheepDTO cheepDTO = DataGenerator.GenerateCheepDTO(5, authorDTO);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(5);
+        CheepDTO cheepDTO = dataGenerator.GenerateCheepDTO(5, authorDTO);
 
         // Act
         IEnumerable<CheepDTO> cheeps = await _repository.GetCheepsFromAuthorAsync(authorDTO.Name, 1, 1);
@@ -193,7 +203,10 @@ public class CheepRepositoryTests
     [Fact]
     public async void CanGetCheepsFromAuthorWithNoCheeps()
     {
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(1);
+        // Arrange
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(1);
 
         // Act
         IEnumerable<CheepDTO> cheeps = await _repository.GetCheepsFromAuthorAsync(authorDTO.Name, 1, 1);
@@ -206,7 +219,9 @@ public class CheepRepositoryTests
     public async void CanGetCheepsFromAuthorWhichDoesNotExists()
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(6);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(6);
 
         // Act
         IEnumerable<CheepDTO> cheeps = await _repository.GetCheepsFromAuthorAsync(authorDTO.Name, 1, 1);
@@ -222,7 +237,9 @@ public class CheepRepositoryTests
     public async void CanGetCheepsFromAuthorPageSize(int pageSize)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(5);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(5);
 
         // Act
         IEnumerable<CheepDTO> cheeps = await _repository.GetCheepsFromAuthorAsync(authorDTO.Name, 1, pageSize);
@@ -238,7 +255,9 @@ public class CheepRepositoryTests
     public async void CanGetCheepsFromAuthorPageSizeTooLarge(int pageSize)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(5);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(5);
 
         // Act
         IEnumerable<CheepDTO> cheeps = await _repository.GetCheepsFromAuthorAsync(authorDTO.Name, 1, pageSize);
@@ -251,7 +270,9 @@ public class CheepRepositoryTests
     public async void CanGetCheepsFromAuthorPageNumber()
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(5);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(5);
 
         // Act
         IEnumerable<CheepDTO> cheeps = await _repository.GetCheepsFromAuthorAsync(authorDTO.Name, 1, 5);
@@ -267,7 +288,9 @@ public class CheepRepositoryTests
     public async void CanGetCheepsFromAuthorPageNumberTooLarge(int pageNumber)
     {
         // Arrange
-        AuthorDTO authorDTO = DataGenerator.GenerateAuthorDTO(5);
+        DataGenerator dataGenerator = new DataGenerator();
+
+        AuthorDTO authorDTO = dataGenerator.GenerateAuthorDTO(5);
 
         // Act
         IEnumerable<CheepDTO> cheeps = await _repository.GetCheepsFromAuthorAsync(authorDTO.Name, pageNumber, 5);

--- a/test/Chirp.Infrastructure.Tests/CheepRepositoryTests.cs
+++ b/test/Chirp.Infrastructure.Tests/CheepRepositoryTests.cs
@@ -91,7 +91,7 @@ public class CheepRepositoryTests
     public void CanCreateCheepWithLongText()
     {
         // Arrange
-        CheepDTO cheepDTO = new CheepDTO("hejsameddejsa", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", "2023-08-01 13:13:23");
+        CheepDTO cheepDTO = new CheepDTO("Cohen Spears", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", "2023-08-01 13:13:23");
 
         // Act and Assert
         try

--- a/test/Chirp.Infrastructure.Tests/Chirp.Infrastructure.Tests.csproj
+++ b/test/Chirp.Infrastructure.Tests/Chirp.Infrastructure.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="34.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">

--- a/test/Chirp.Infrastructure.Tests/DataGenerator.cs
+++ b/test/Chirp.Infrastructure.Tests/DataGenerator.cs
@@ -1,0 +1,66 @@
+namespace Chirp.Infrastructure.Tests;
+
+public static class DataGenerator
+{
+    public static AuthorDTO GenerateAuthorDTO(int seed)
+    {
+        Randomizer.Seed = new Random(seed);
+
+        return new Faker<AuthorDTO>().CustomInstantiator(a =>
+            new AuthorDTO
+            (
+                a.Name.FullName(),
+                a.Internet.Email(a.Name.FirstName(), a.Name.LastName())
+            )
+        ).Generate();
+    }
+
+    public static Author GenerateAuthor(int seed)
+    {
+        Randomizer.Seed = new Random(seed);
+
+        return new Faker<Author>().CustomInstantiator(a =>
+            new Author()
+            {
+                Name = a.Name.FullName(),
+                Email = a.Internet.Email(a.Name.FirstName(), a.Name.LastName()),
+                Cheeps = new List<Cheep>()
+            }
+        ).Generate();
+    }
+
+    public static CheepDTO GenerateCheepDTO(int seed, AuthorDTO authorDTO)
+    {
+        Randomizer.Seed = new Random(seed);
+
+        return new Faker<CheepDTO>().CustomInstantiator(a =>
+            new CheepDTO
+            (
+                authorDTO.Name,
+                a.Lorem.Sentence(5),
+                GetTimeStamp(a.Random.Double(0, 1000000000))
+            )
+        ).Generate();
+    }
+
+    public static Cheep GenerateCheep(int seed, Author author)
+    {
+        Randomizer.Seed = new Random(seed);
+
+        return new Faker<Cheep>().CustomInstantiator(a =>
+            new Cheep()
+            {
+                Author = author,
+                Text = a.Lorem.Sentence(5),
+                TimeStamp = DateTime.Parse(GetTimeStamp(a.Random.Double(0, 1000000000)))
+            }
+        ).Generate();
+    }
+
+    private static string GetTimeStamp(double unixTimeStamp)
+    {
+        DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        dateTime = dateTime.AddSeconds(unixTimeStamp);
+        return dateTime.ToString("yyyy/MM/dd HH:mm:ss");
+    }
+}

--- a/test/Chirp.Infrastructure.Tests/DataGenerator.cs
+++ b/test/Chirp.Infrastructure.Tests/DataGenerator.cs
@@ -1,8 +1,8 @@
 namespace Chirp.Infrastructure.Tests;
 
-public static class DataGenerator
+public class DataGenerator
 {
-    public static AuthorDTO GenerateAuthorDTO(int seed)
+    public AuthorDTO GenerateAuthorDTO(int seed)
     {
         Randomizer.Seed = new Random(seed);
 
@@ -15,7 +15,7 @@ public static class DataGenerator
         ).Generate();
     }
 
-    public static Author GenerateAuthor(int seed)
+    public Author GenerateAuthor(int seed)
     {
         Randomizer.Seed = new Random(seed);
 
@@ -29,7 +29,7 @@ public static class DataGenerator
         ).Generate();
     }
 
-    public static CheepDTO GenerateCheepDTO(int seed, AuthorDTO authorDTO)
+    public CheepDTO GenerateCheepDTO(int seed, AuthorDTO authorDTO)
     {
         Randomizer.Seed = new Random(seed);
 
@@ -43,7 +43,7 @@ public static class DataGenerator
         ).Generate();
     }
 
-    public static Cheep GenerateCheep(int seed, Author author)
+    public Cheep GenerateCheep(int seed, Author author)
     {
         Randomizer.Seed = new Random(seed);
 
@@ -57,7 +57,7 @@ public static class DataGenerator
         ).Generate();
     }
 
-    private static string GetTimeStamp(double unixTimeStamp)
+    private string GetTimeStamp(double unixTimeStamp)
     {
         DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
         dateTime = dateTime.AddSeconds(unixTimeStamp);

--- a/test/Chirp.Infrastructure.Tests/GlobalUsings.cs
+++ b/test/Chirp.Infrastructure.Tests/GlobalUsings.cs
@@ -1,4 +1,5 @@
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.Data.Sqlite;
 global using Chirp.Core;
+global using Bogus;
 global using Xunit;

--- a/test/Chirp.Web.Tests/CustomWebApplicationFactory.cs
+++ b/test/Chirp.Web.Tests/CustomWebApplicationFactory.cs
@@ -1,3 +1,5 @@
+namespace Chirp.Web.Tests;
+
 public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProgram> where TProgram : class
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/test/Chirp.Web.Tests/GlobalUsings.cs
+++ b/test/Chirp.Web.Tests/GlobalUsings.cs
@@ -4,5 +4,4 @@ global using Microsoft.EntityFrameworkCore;
 global using Microsoft.AspNetCore.Hosting;
 global using Microsoft.AspNetCore.Mvc.Testing;
 global using Microsoft.Extensions.DependencyInjection;
-global using Chirp.Web;
 global using Chirp.Infrastructure;


### PR DESCRIPTION
This branch has implemented bogus, such that data does not have to manually be written in the test cases. You can now choose a seed and a datapoint will be create. The same seed always give the same outcome.

The seeds 1 thourgh 5 is reserved for Seeding the database and is used in certian testcases.