### PR TITLE
Modify user timeline

### DIFF
--- a/src/Chirp.Core/IAuthorRepository.cs
+++ b/src/Chirp.Core/IAuthorRepository.cs
@@ -5,4 +5,5 @@ public interface IAuthorRepository
     public void CreateAuthor(AuthorDTO author);
     public void DeleteAuthor(string author);
     public Task<AuthorDTO> GetAuthorFromNameAsync(string name);
+    public bool CheckAuthorExists(string author);
 }

--- a/src/Chirp.Infrastructure/AuthorRepository.cs
+++ b/src/Chirp.Infrastructure/AuthorRepository.cs
@@ -57,4 +57,18 @@ public class AuthorRepository : IAuthorRepository
         }
 
     }
+
+    public bool CheckAuthorExists(string author)
+    {
+        try
+        {
+            _context.Authors.Single(a => a.Name.Equals(author));
+            return true;
+
+        }
+        catch
+        {
+            return false;
+        }
+    }
 }

--- a/src/Chirp.Web/Pages/Profile.cshtml
+++ b/src/Chirp.Web/Pages/Profile.cshtml
@@ -33,6 +33,28 @@
                             <strong>
                                 <a href="/@following">@following</a>
                             </strong>
+                             @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != following &&
+               User.Identity.IsAuthenticated)
+                {
+                    @if (await Model.FollowRepository.CheckFollowExistsAsync(User.Identity.Name, following))
+                    {
+                        <span style="float: right;">
+                            <form asp-page-handler="Unfollow" method="post">
+                                <input type="hidden" name="author" value="@(following)" />
+                                <button id="unfollowButton" type="submit">Unfollow</button>
+                            </form>
+                        </span>
+                    }
+                    else
+                    {
+                        <span style="float: right;">
+                            <form asp-page-handler="Follow" method="post">
+                                <input type="hidden" name="author" value="@(following)" />
+                                <button id="followButton" type="submit">Follow</button>
+                            </form>
+                        </span>
+                    }
+                }
                         </p>
                     </li>
                 }

--- a/src/Chirp.Web/Pages/Profile.cshtml
+++ b/src/Chirp.Web/Pages/Profile.cshtml
@@ -94,8 +94,17 @@
                                 <strong>
                                     <a href="/@cheep.Author">@cheep.Author</a>
                                 </strong>
+                                <div>
+                        <div style="display: flex; justify-content: space-between;">
+                            <div>
                                 @cheep.Text
+                            </div>
+                            <div style="white-space: nowrap; align-self: flex-end;">
                                 <small>&mdash; @cheep.TimeStamp</small>
+                            </div>
+
+                        </div>
+                    </div>
                             </p>
                         </li>
                     }

--- a/src/Chirp.Web/Pages/Profile.cshtml
+++ b/src/Chirp.Web/Pages/Profile.cshtml
@@ -33,28 +33,27 @@
                             <strong>
                                 <a href="/@following">@following</a>
                             </strong>
-                             @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != following &&
-               User.Identity.IsAuthenticated)
-                {
-                    @if (await Model.FollowRepository.CheckFollowExistsAsync(User.Identity.Name, following))
-                    {
-                        <span style="float: right;">
-                            <form asp-page-handler="Unfollow" method="post">
-                                <input type="hidden" name="author" value="@(following)" />
-                                <button id="unfollowButton" type="submit">Unfollow</button>
-                            </form>
-                        </span>
-                    }
-                    else
-                    {
-                        <span style="float: right;">
-                            <form asp-page-handler="Follow" method="post">
-                                <input type="hidden" name="author" value="@(following)" />
-                                <button id="followButton" type="submit">Follow</button>
-                            </form>
-                        </span>
-                    }
-                }
+
+                            @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != following &&
+                           User.Identity.IsAuthenticated)
+                            {
+                            <div style="margin: 5px 0;">
+                                    @if (await Model.FollowRepository.CheckFollowExistsAsync(User.Identity.Name, following))
+                                    {
+                                    <form asp-page-handler="Unfollow" method="post">
+                                        <input type="hidden" name="author" value="@(following)" />
+                                        <button id="unfollowButton" type="submit">Unfollow</button>
+                                    </form>
+                                    }
+                                    else
+                                    {
+                                    <form asp-page-handler="Follow" method="post">
+                                        <input type="hidden" name="author" value="@(following)" />
+                                        <button id="followButton" type="submit">Follow</button>
+                                    </form>
+                                    }
+                            </div>
+                            }
                         </p>
                     </li>
                 }
@@ -94,17 +93,17 @@
                                 <strong>
                                     <a href="/@cheep.Author">@cheep.Author</a>
                                 </strong>
-                                <div>
-                        <div style="display: flex; justify-content: space-between;">
                             <div>
-                                @cheep.Text
-                            </div>
-                            <div style="white-space: nowrap; align-self: flex-end;">
-                                <small>&mdash; @cheep.TimeStamp</small>
-                            </div>
+                                <div style="display: flex; justify-content: space-between;">
+                                    <div>
+                                            @cheep.Text
+                                    </div>
+                                    <div style="white-space: nowrap; align-self: flex-end;">
+                                        <small>&mdash; @cheep.TimeStamp</small>
+                                    </div>
 
-                        </div>
-                    </div>
+                                </div>
+                            </div>
                             </p>
                         </li>
                     }

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -58,8 +58,15 @@
                         </span>
                     }
                     <div>
-                        @cheep.Text
-                        <small>&mdash; @cheep.TimeStamp</small>
+                        <div style="display: flex; justify-content: space-between;">
+                            <div>
+                                @cheep.Text
+                            </div>
+                            <div style="white-space: nowrap; align-self: flex-end;">
+                                <small>&mdash; @cheep.TimeStamp</small>
+                            </div>
+
+                        </div>
                     </div>
                 </li>
             }

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -30,31 +30,37 @@
             @foreach (CheepDTO cheep in Model.Cheeps)
             {
                 <li>
-                    <p>
+                    <span style="display: inline-block;">
                         <strong>
                             <a href="/@cheep.Author">@cheep.Author</a>
                         </strong>
-                        @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != cheep.Author &&
-                       User.Identity.IsAuthenticated)
-                        {
+                    </span>
+
+                    @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != cheep.Author &&
+                   User.Identity.IsAuthenticated)
+                    {
+                        <span style="display: inline-block;">
                             @if (await Model.FollowRepository.CheckFollowExistsAsync(User.Identity.Name, cheep.Author))
                             {
-                            <form asp-page-handler="Unfollow" method="post">
-                                <input type="hidden" name="author" value="@(cheep.Author)" />
-                                <button id="unfollowButton" type="submit">Unfollow</button>
-                            </form>
+
+                                <form asp-page-handler=" Unfollow" method="post">
+                                    <input type="hidden" name="author" value="@(cheep.Author)" />
+                                    <button id="unfollowButton" type="submit">Unfollow</button>
+                                </form>
                             }
                             else
                             {
-                            <form asp-page-handler="Follow" method="post">
-                                <input type="hidden" name="author" value="@(cheep.Author)" />
-                                <button id="followButton" type="submit">Follow</button>
-                            </form>
+                                <form asp-page-handler="Follow" method="post">
+                                    <input type="hidden" name="author" value="@(cheep.Author)" />
+                                    <button id="followButton" type="submit">Follow</button>
+                                </form>
                             }
-                        }
+                        </span>
+                    }
+                    <div>
                         @cheep.Text
-                    <small>&mdash; @cheep.TimeStamp</small>
-                    </p>
+                        <small>&mdash; @cheep.TimeStamp</small>
+                    </div>
                 </li>
             }
         </ul>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -57,39 +57,37 @@
                     @foreach (CheepDTO cheep in Model.Cheeps)
                     {
                         <li>
-                            <p style="display: flex; justify-content: space-between;">
+                            <span style="display: inline-block;">
+                                <strong>
+                                    <a href="/@cheep.Author">@cheep.Author</a>
+                                </strong>
+                            </span>
+
+                            @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != cheep.Author &&
+                           User.Identity.IsAuthenticated)
+                            {
                                 <span style="display: inline-block;">
-                                    <strong>
-
-                                        <a href="/@cheep.Author">@cheep.Author</a>
-
-                                    </strong>
-                                </span>
-                                @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != cheep.Author &&
-                               User.Identity.IsAuthenticated)
-                                {
                                     @if (await Model.FollowRepository.CheckFollowExistsAsync(User.Identity.Name, cheep.Author))
                                     {
-                                        <span style="display: inline-block;">
-                                            <form asp-page-handler=" Unfollow" method="post">
-                                                <input type="hidden" name="author" value="@(cheep.Author)" />
-                                                <button id="unfollowButton" type="submit">Unfollow</button>
-                                            </form>
-                                        </span>
+
+                                        <form asp-page-handler=" Unfollow" method="post">
+                                            <input type="hidden" name="author" value="@(cheep.Author)" />
+                                            <button id="unfollowButton" type="submit">Unfollow</button>
+                                        </form>
                                     }
                                     else
                                     {
-                                        <span style="display: inline-block;">
-                                            <form asp-page-handler="Follow" method="post">
-                                                <input type="hidden" name="author" value="@(cheep.Author)" />
-                                                <button id="followButton" type="submit">Follow</button>
-                                            </form>
-                                        </span>
+                                        <form asp-page-handler="Follow" method="post">
+                                            <input type="hidden" name="author" value="@(cheep.Author)" />
+                                            <button id="followButton" type="submit">Follow</button>
+                                        </form>
                                     }
-                                }
+                                </span>
+                            }
+                            <div>
                                 @cheep.Text
                                 <small>&mdash; @cheep.TimeStamp</small>
-                            </p>
+                            </div>
                         </li>
                     }
                 </ul>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -7,86 +7,126 @@
     var author = HttpContext.GetRouteValue("author");
 }
 
-<div class="cheepbox">
-    @if (User.Identity != null && User.Identity.IsAuthenticated)
-    {
-        <h3>What's on your mind @(User.Identity.Name)</h3>
-        <form method="post">
-            <input style="float: left" type="text" asp-for="Text">
-            <input type="submit" value="Share" , asp-action="OnPost(text)">
-        </form>
-    }
-    else
-    {
-        <em>You can't cheep when you aren't logged in!</em>
-    }
-</div>
-
 <div>
-    <h2> @author's Timeline </h2>
-
-    @if (Model.Cheeps.Any())
+    @if (Model.AuthorRepository.CheckAuthorExists(author.ToString()))
     {
-        <ul id="messagelist" class="cheeps">
-            @foreach (CheepDTO cheep in Model.Cheeps)
+        <div class="cheepbox">
+            @if (User.Identity != null && User.Identity.IsAuthenticated)
             {
-                <li>
-                    <p>
-                        <strong>
-                            <a href="/@cheep.Author">@cheep.Author</a>
-                        </strong>
-                        @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != cheep.Author &&
-                       User.Identity.IsAuthenticated)
-                        {
-                            @if (await Model.FollowRepository.CheckFollowExistsAsync(User.Identity.Name, cheep.Author))
-                            {
+                <h3>What's on your mind @(User.Identity.Name)</h3>
+                <form method="post">
+                    <input style="float: left" type="text" asp-for="Text">
+                    <input type="submit" value="Share" , asp-action="OnPost(text)">
+                </form>
+            }
+            else
+            {
+                <em>You can't cheep when you aren't logged in!</em>
+            }
+        </div>
+
+        <div>
+            <h2> <span style="display: inline-block;">@author's Timeline</span>
+                @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != author &&
+               User.Identity.IsAuthenticated)
+                {
+                    @if (await Model.FollowRepository.CheckFollowExistsAsync(User.Identity.Name, author.ToString()))
+                    {
+                        <span style="float: right;">
                             <form asp-page-handler="Unfollow" method="post">
-                                <input type="hidden" name="author" value="@(cheep.Author)" />
+                                <input type="hidden" name="author" value="@(author)" />
                                 <button id="unfollowButton" type="submit">Unfollow</button>
                             </form>
-                            }
-                            else
-                            {
+                        </span>
+                    }
+                    else
+                    {
+                        <span style="float: right;">
                             <form asp-page-handler="Follow" method="post">
-                                <input type="hidden" name="author" value="@(cheep.Author)" />
+                                <input type="hidden" name="author" value="@(author)" />
                                 <button id="followButton" type="submit">Follow</button>
                             </form>
-                            }
-                        }
-                        @cheep.Text
-                    <small>&mdash; @cheep.TimeStamp</small>
-                    </p>
-                </li>
+                        </span>
+                    }
+                }
+            </h2>
+
+            @if (Model.Cheeps.Any())
+            {
+                <ul id="messagelist" class="cheeps">
+                    @foreach (CheepDTO cheep in Model.Cheeps)
+                    {
+                        <li>
+                            <p style="display: flex; justify-content: space-between;">
+                                <span style="display: inline-block;">
+                                    <strong>
+
+                                        <a href="/@cheep.Author">@cheep.Author</a>
+
+                                    </strong>
+                                </span>
+                                @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != cheep.Author &&
+                               User.Identity.IsAuthenticated)
+                                {
+                                    @if (await Model.FollowRepository.CheckFollowExistsAsync(User.Identity.Name, cheep.Author))
+                                    {
+                                        <span style="display: inline-block;">
+                                            <form asp-page-handler=" Unfollow" method="post">
+                                                <input type="hidden" name="author" value="@(cheep.Author)" />
+                                                <button id="unfollowButton" type="submit">Unfollow</button>
+                                            </form>
+                                        </span>
+                                    }
+                                    else
+                                    {
+                                        <span style="display: inline-block;">
+                                            <form asp-page-handler="Follow" method="post">
+                                                <input type="hidden" name="author" value="@(cheep.Author)" />
+                                                <button id="followButton" type="submit">Follow</button>
+                                            </form>
+                                        </span>
+                                    }
+                                }
+                                @cheep.Text
+                                <small>&mdash; @cheep.TimeStamp</small>
+                            </p>
+                        </li>
+                    }
+                </ul>
             }
-        </ul>
+            else
+            {
+                <em>There are no cheeps.</em>
+            }
+        </div>
+
+        <div style="text-align:center;">
+            @if (Model.CurrentPage > 1)
+            {
+                <a href="/@author/?page=1">[&lt;&lt;]</a>
+                <a href="/@author/?page=@(Model.CurrentPage - 1)">[&lt;]</a>
+            }
+
+            @for (int i = int.Max(1, Model.CurrentPage - 5); i <= int.Min(Model.PageCount, Model.CurrentPage + 5); i++)
+            {
+                if (i == Model.CurrentPage)
+                {
+                    <b>[@i]</b>
+                    continue;
+                }
+
+                <a href="/@author/?page=@i">[@i]</a>
+            }
+
+            @if (Model.CurrentPage < Model.PageCount)
+            {
+                <a href="/@author/?page=@(Model.CurrentPage + 1)">[&gt;]</a>
+                <a href="/@author/?page=@Model.PageCount">[&gt;&gt;]</a>
+            }
+        </div>
     }
     else
     {
-        <em>There are no cheeps.</em>
-    }
-</div>
-
-<div style="text-align:center;">
-    @if (Model.CurrentPage > 1)
-    {
-        <a href="/@author/?page=1">[&lt;&lt;]</a>
-        <a href="/@author/?page=@(Model.CurrentPage - 1)">[&lt;]</a>
-    }
-
-    @for (int i = int.Max(1, Model.CurrentPage - 5); i <= int.Min(Model.PageCount, Model.CurrentPage + 5); i++)
-    {
-        if (i == Model.CurrentPage)
-        {
-            <b>[@i]</b>
-            continue;
-        }
-
-        <a href="/@author/?page=@i">[@i]</a>
-    }
-
-    @if (Model.CurrentPage < Model.PageCount)
-    {
-        <a href="/@author/?page=@(Model.CurrentPage + 1)">[&gt;]</a>
-        <a href="/@author/?page=@Model.PageCount">[&gt;&gt;]</a>
+        <em>This user does not exist!</em>
     }
 </div>

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -90,8 +90,15 @@
                                 </span>
                             }
                             <div>
-                                @cheep.Text
-                                <small>&mdash; @cheep.TimeStamp</small>
+                                <div style="display: flex; justify-content: space-between;">
+                                    <div>
+                                        @cheep.Text
+                                    </div>
+                                    <div style="white-space: nowrap; align-self: flex-end;">
+                                        <small>&mdash; @cheep.TimeStamp</small>
+                                    </div>
+
+                                </div>
                             </div>
                         </li>
                     }

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -27,7 +27,7 @@
 
         <div>
             <h2> <span style="display: inline-block;">@author's Timeline</span>
-                @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != author &&
+                @if (User.Identity != null && User.Identity.Name != null && User.Identity.Name != author.ToString() &&
                User.Identity.IsAuthenticated)
                 {
                     @if (await Model.FollowRepository.CheckFollowExistsAsync(User.Identity.Name, author.ToString()))
@@ -50,6 +50,11 @@
                     }
                 }
             </h2>
+            <div>
+                <h3> Following: @(Model.FollowingsCount) </h3>
+                <h3> Followers: @(Model.FollowersCount) </h3>
+            </div>
+
 
             @if (Model.Cheeps.Any())
             {

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml.cs
@@ -10,6 +10,8 @@ public class UserTimelineModel : PageModel
     public IFollowRepository FollowRepository { get; private set; }
     public IEnumerable<CheepDTO> Cheeps { get; set; }
     public string Text { get; set; }
+    public int FollowersCount { get; set; }
+    public int FollowingsCount { get; set; }
     public int CurrentPage { get; set; }
     public int PageCount { get; set; }
 
@@ -78,6 +80,8 @@ public class UserTimelineModel : PageModel
             }
 
             Cheeps = await CheepRepository.GetUserTimelineCheepsAsync(author, followings, page, pageSize);
+            FollowersCount = await FollowRepository.GetFollowersCountAsync(User.Identity.Name);
+            FollowingsCount = await FollowRepository.GetFollowingsCountAsync(User.Identity.Name);
 
             return Page();
         }


### PR DESCRIPTION
Things ive added:
you cant access the timeline of a user that doesnt exists (by typing in a random username in the url)
you can follow people from their timeline (added at the top of the page, next to username)
the authenticated user can see the number of other users followers and following on their timeline
adjustments to the style and position of the follow/unfollow button on all pages (public, user timeline and profile)
adjustments to the position of the timestamp on all cheeps - personal preferences, let me know if i should change it back (screenshot of changed display is attached)
<img width="519" alt="image" src="https://github.com/ITU-BDSA23-GROUP19/Chirp/assets/123461767/9ee2b23c-bc73-49e0-983b-c2da5dde986e">
